### PR TITLE
pyproject.toml: Remove project.scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,3 @@ Homepage = "https://github.com/itsdarik/chai"
 Repository = "https://github.com/itsdarik/chai"
 Issues = "https://github.com/itsdarik/chai/issues"
 Changelog = "https://github.com/itsdarik/chai/releases"
-
-[project.scripts]
-chai = "chai.cli:main"


### PR DESCRIPTION
`chai` is now a virtual project and no longer packaged.

This fixes a warning printed by `uv sync`.

Closes #8